### PR TITLE
Test if observable exists in Binding.emit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "domodel",
-	"version": "2.2.2",
+	"version": "2.2.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "domodel",
-			"version": "2.2.2",
+			"version": "2.2.3",
 			"license": "MIT",
 			"devDependencies": {
 				"ava": "^5.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "domodel",
-	"version": "2.2.2",
+	"version": "2.2.3",
 	"main": "index.js",
 	"type": "module",
 	"description": "Front-end library",

--- a/src/binding.js
+++ b/src/binding.js
@@ -73,6 +73,7 @@ Binding.prototype._onConnected = function() {
  * @param {boolean}    [unshift=false]
  * @returns {Listener}
  * @example binding.listen(observable, "myEvent", message => console.log(message))
+ * Note: When listening on a non-Observable target, the Binding take care of mapping the listener to a given target. This mapping is inherited by all children which means that children are able to emit to any non-Observable target Listener of any parent.
  */
 Binding.prototype.listen = function(target, eventName, callback, unshift = false) {
 	let listener
@@ -102,7 +103,11 @@ Binding.prototype.listen = function(target, eventName, callback, unshift = false
  */
 Binding.prototype.emit = function(target, ...emitArgument) {
 	const observable = this.observables.get(target)
-	observable.emit(...emitArgument)
+	if(observable) {
+		observable.emit(...emitArgument)
+	} else {
+		throw new Error("No listener were found on this Binding for this Observable")
+	}
 }
 
 /**

--- a/src/binding.test.js
+++ b/src/binding.test.js
@@ -311,3 +311,15 @@ ava("listen object", (test) => {
 	test.deepEqual(targetData, ["childFoo", "foo", "foo2"])
 	test.deepEqual(target2Data, ["childBar", "bar", "bar2"])
 })
+
+ava("emit fail", (test) => {
+	const target = {}
+	const TestBinding = class extends Binding {
+		onCreated() {
+			this.emit(target, "test", "foo")
+		}
+	}
+	test.throws(() => {
+		Core.run({ tagName: "button" }, { binding: new TestBinding(), target: test.context.document.body })
+	}, { message: "No listener were found on this Binding for this Observable" })
+})


### PR DESCRIPTION
Currently, when emitting from a Binding to a target that has no registered Listener a general Error is thrown. 

