### PR TITLE
Event listeners should be registered prior to calling onCreated

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -32,10 +32,11 @@ export function run(model, runParameters) {
 	const element = createElement(target, model, binding)
 	binding.root = element
 	binding.model = model
-	binding.onCreated()
+	/** Event listeners should be registered prior to calling onCreated as they might be emitted from within onCreated */
 	for (const name of getFunctionNames(binding.eventListener)) {
 		binding.listen(binding.eventListener.observable, name, binding.eventListener[name].bind(binding), true)
 	}
+	binding.onCreated()
 	connectElement(target, element, method, binding)
 	return element
 }


### PR DESCRIPTION
Sometimes it is desired that self-made event listeners are called from within onCreated, this patch make it so that the event listeners are registered prior to calling onCreated.