### PR TITLE
Use Binding instance in model functions

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -29,6 +29,9 @@ export const METHOD = {
 */
 export function run(model, runParameters) {
 	const { target = runParameters.parentNode, binding = new Binding(), method = METHOD.APPEND_CHILD } = runParameters
+	if(typeof model === "function") {
+		model = model.apply(binding, runParameters.modelArguments)
+	}
 	const element = createElement(target, model, binding)
 	binding.root = element
 	binding.model = model

--- a/src/core.test.js
+++ b/src/core.test.js
@@ -421,3 +421,19 @@ ava("eventListener inheritance", (test) => {
 
 
 })
+
+ava("Bind Binding instance to model function", test => {
+	test.plan(2)
+	const binding = new Binding()
+	function myModel() {
+		test.is(this, binding)
+		test.deepEqual(arguments, ["foo", "bar"])
+		return {
+			tagName: "div",
+			className: "simplemodel",
+			id: "simplemodel",
+			textContent: "My first simple model"
+		}
+	}
+	Core.run(myModel, { binding, target: test.context.document.body, modelArguments: ["foo", "bar"] })
+})


### PR DESCRIPTION
Sometimes we may want to use the Binding instance inside model functions, it is often because the Binding constructor parameters are pretty much the same as the ones that are passed to the model function.